### PR TITLE
Fix rspec for ruby 3.0 over

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ then set `.kaminari_connection` to field type and resolve it as a kaminari objec
 
 ```rb
 class Types::Query < GraphQL::Schema::Object
-  field :articles, ArticleType.kaminari_connection
+  field :articles, **ArticleType.kaminari_connection
 
   def articles(page: nil, per: nil)
     Article.all.page(page).per(per)
@@ -89,7 +89,7 @@ You can define additional field arguments in its block:
 
 ```rb
 class Types::Query < GraphQL::Schema::Object
-  field(:articles, ArticleType.kaminari_connection) do
+  field(:articles, **ArticleType.kaminari_connection) do
     argument :scope, Types::ArticleScope, required: true
   end
 
@@ -105,7 +105,7 @@ Give `{ without_count: true }` to `.kaminari_connection`:
 
 ```rb
 class Types::Query < GraphQL::Schema::Object
-  field :articles, ArticleType.kaminari_connection(without_count: true)
+  field :articles, **ArticleType.kaminari_connection(without_count: true)
 
   def articles(page: nil, per: nil)
     Article.all.page(page).per(per).without_count

--- a/spec/graphql/kaminari_connection_spec.rb
+++ b/spec/graphql/kaminari_connection_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe GraphQL::KaminariConnection do
 
       Class.new(GraphQL::Schema::Object) do
         graphql_name 'Query'
-        field :foos, foo_type.kaminari_connection
+        field :foos, **foo_type.kaminari_connection
 
         def foos(page: nil, per: nil)
           Kaminari.paginate_array(1.upto(100).to_a).page(page).per(per)
@@ -182,7 +182,7 @@ RSpec.describe GraphQL::KaminariConnection do
 
       Class.new(GraphQL::Schema::Object) do
         graphql_name 'Query'
-        field(:foos, foo_type.kaminari_connection) do
+        field(:foos, **foo_type.kaminari_connection) do
           argument :max, 'Int', required: true
         end
 
@@ -231,7 +231,7 @@ RSpec.describe GraphQL::KaminariConnection do
 
       Class.new(GraphQL::Schema::Object) do
         graphql_name 'Query'
-        field :posts, post_type.kaminari_connection(without_count: true)
+        field :posts, **post_type.kaminari_connection(without_count: true)
 
         def posts(page: nil, per: nil)
           Post.all.page(page).per(per).without_count


### PR DESCRIPTION
Closed https://github.com/increments/graphql-kaminari_connection/issues/27
I fixed rspec and Readme for separation of positional and keyword arguments in Ruby 3.0.

## REF 
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
