### PR TITLE
Support only currently living ruby versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7.6, 3.0.4, 3.1.2]
+        ruby: [3.1.6, 3.2.6, 3.3.6]
     name: Ruby ${{ matrix.ruby }}
     steps:
       - name: Get branch names
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.6
+          ruby-version: 3.1.6
           bundler-cache: true
       - name: Test & publish code coverage
         if: "${{ env.CC_TEST_REPORTER_ID != '' }}"
@@ -58,7 +58,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 2.7.6
+          ruby-version: 3.1.6
 
       - name: Run rubocop
         run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
   NewCops: enable
 
 Metrics/BlockLength:

--- a/graphql-kaminari_connection.gemspec
+++ b/graphql-kaminari_connection.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.1'
 
   spec.add_dependency 'graphql', '~> 1.9'
   spec.add_dependency 'kaminari', '~> 1.1'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ require 'graphql/kaminari_connection'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir["#{__dir__}/support/**/*.rb"].sort.each { |f| require f }
+Dir["#{__dir__}/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->

This PR fixes https://github.com/increments/graphql-kaminari_connection/issues/30

This PR drops support for Ruby versions which reaches EOL.
Besides, This PR changes CI environment to run Ruby versions on CI to use supported versions.

Ref: https://endoflife.date/ruby
