### PR TITLE
Update rubocop to 1.69.2 and its configurations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 Style/Documentation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,9 @@ AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
 
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
 Metrics/BlockLength:
   Enabled: false
 

--- a/graphql-kaminari_connection.gemspec
+++ b/graphql-kaminari_connection.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '0.11.3'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 1.37.1'
+  spec.add_development_dependency 'rubocop', '~> 1.69.2'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.14.1'
   spec.add_development_dependency 'simplecov', '~> 0.13'
   spec.add_development_dependency 'sqlite3', '~> 1.3'


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->

This PR updates rubocop to [1.69.2](https://github.com/rubocop/rubocop/releases/tag/v1.69.2) and update its configurations.

## Changes of rubocop configurations

This PR also adds these changes to suppress diffs of newly added gems and fix warned configurations.

- Disable [Gemspec/DevelopmentDependencies](https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecdevelopmentdependencies) for now
  - This cop enforces that development dependencies for this gem are specified in Gemfile. Disable this to suppress diffs of this PR.
- Fix typo of cop name of [Layout/LineLength](https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinelength)

