### PR TITLE
Update rubocop-rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-rspec
+
 AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
@@ -13,6 +16,19 @@ Metrics/MethodLength:
 
 Layout/LineLength:
   Max: 120
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/ExampleWording:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/SpecFilePathFormat:
+  CustomTransform:
+    GraphQL: graphql
 
 Style/Documentation:
   Enabled: false

--- a/graphql-kaminari_connection.gemspec
+++ b/graphql-kaminari_connection.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.69.2'
-  spec.add_development_dependency 'rubocop-rspec', '~> 2.14.1'
+  spec.add_development_dependency 'rubocop-rspec', '~> 3.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.13'
   spec.add_development_dependency 'sqlite3', '~> 1.3'
   spec.metadata['rubygems_mfa_required'] = 'true'

--- a/spec/graphql/kaminari_connection_spec.rb
+++ b/spec/graphql/kaminari_connection_spec.rb
@@ -4,15 +4,15 @@ require 'graphql'
 require 'kaminari'
 
 RSpec.describe GraphQL::KaminariConnection do
-  it 'has a version number' do
-    expect(GraphQL::KaminariConnection::VERSION).not_to be nil
-  end
-
   let(:schema) do
     query = query_type
     Class.new(GraphQL::Schema) do
       query query
     end
+  end
+
+  it 'has a version number' do
+    expect(GraphQL::KaminariConnection::VERSION).not_to be_nil
   end
 
   context 'with Kaminari::PaginatableArray' do
@@ -290,10 +290,7 @@ RSpec.describe GraphQL::KaminariConnection do
             'pageData' => {
               'currentPage' => 1
             },
-            'items' => match_array([
-                                     { 'title' => 'This Is A Pen' },
-                                     { 'title' => 'GraphQL Is Awesome' }
-                                   ])
+            'items' => contain_exactly({ 'title' => 'This Is A Pen' }, { 'title' => 'GraphQL Is Awesome' })
           }
         }
       )


### PR DESCRIPTION
(Note: This PR based on https://github.com/increments/graphql-kaminari_connection/pull/34. merge it first.)

This PR updates rubocop-rspec to [3.3.0](https://github.com/rubocop/rubocop-rspec/releases/tag/v3.3.0).
This PR also updates rubocop configurations and disable some cops unsuitable for our codes.