### PR TITLE
Add release-gem.yml and bump up version to v1.1.0

### DIFF
--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -1,0 +1,22 @@
+name:
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release-gem:
+    name: Release gem on RubyGems.org
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 3.1.6
+      - uses: rubygems/release-gem@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# v1.1.0
+
+- Support graphql-ruby 2.x [#32](https://github.com/increments/graphql-kaminari_connection/pull/32)
+- Support only currently living ruby versions [#33](https://github.com/increments/graphql-kaminari_connection/pull/33)
+
+# v1.0.0
+
+- Change support ruby version [#26](https://github.com/increments/graphql-kaminari_connection/pull/26)
+- Work with graphql-ruby 1.9.0 [#20](https://github.com/increments/graphql-kaminari_connection/pull/20)
+
+# v0.1.0

--- a/lib/graphql/kaminari_connection/version.rb
+++ b/lib/graphql/kaminari_connection/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module KaminariConnection
-    VERSION = '1.0.0'
+    VERSION = '1.1.0'
   end
 end


### PR DESCRIPTION
- Add GitHub Actgions to release this gem with https://github.com/rubygems/release-gem.
  - When you run this workflow, the git tag for the version is created and gem with the version is pushed to rubygems.
  - This workflow does authorizations to rubygems with OIDC (https://guides.rubygems.org/trusted-publishing/adding-a-publisher/).
- Write CHANGELOG.md by hand.
- Bump up the version to v1.1.0