### PR TITLE
Use ruby v3.2.6 on release-gem.yml

### DIFF
--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -18,5 +18,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 3.1.6
+          # Use ruby v3.2.6 to use recent rubygems (v3.4.8+).
+          # release-gem requires rubygems v3.4.8+, because release-gem uses `gem exec` command and rubygems v3.4.8+ supports it.
+          # https://github.com/rubygems/release-gem/blob/a25424ba2ba8b387abc8ef40807c2c85b96cbe32/rubygems-attestation-patch.rb#L40-L45
+          ruby-version: 3.2.6
       - uses: rubygems/release-gem@v1


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->

WIth this PR, release-gem workflow uses ruby v3.2.6.

## Why

This is because the workflow fails to sign gem with ruby v3.1.6 (but it can push gem to rubygems without sign).

![image](https://github.com/user-attachments/assets/7fbfe506-0683-40a8-bbf8-63e3d2e6b778)

([link](https://github.com/increments/graphql-kaminari_connection/actions/runs/12426970789/job/34696043703))

[rubygems/release-gem@v1](https://github.com/rubygems/release-gem/tree/v1) action require recent rubygems (v3.4.8+).
The action internally uses `gem exec` to sign gem ([ref](https://github.com/rubygems/release-gem/blob/a25424ba2ba8b387abc8ef40807c2c85b96cbe32/rubygems-attestation-patch.rb#L40-L45)), and `gem exec` is introduced on [rubygems v3.4.8](https://github.com/rubygems/rubygems/blob/master/CHANGELOG.md#348--2023-03-08).

This PR updates ruby version on release-gem.yml workflow to use rubygems v3.4.8+.
