### PR TITLE
Fix github action version by hash

### DIFF
--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -13,13 +13,13 @@ jobs:
       contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@c95ae3725f6ebdd095f2bd19caed7ebc14435ba5 # v1.243.0
         with:
           bundler-cache: true
           # Use ruby v3.2.6 to use recent rubygems (v3.4.8+).
           # release-gem requires rubygems v3.4.8+, because release-gem uses `gem exec` command and rubygems v3.4.8+ supports it.
           # https://github.com/rubygems/release-gem/blob/a25424ba2ba8b387abc8ef40807c2c85b96cbe32/rubygems-attestation-patch.rb#L40-L45
           ruby-version: 3.2.6
-      - uses: rubygems/release-gem@v1
+      - uses: rubygems/release-gem@a25424ba2ba8b387abc8ef40807c2c85b96cbe32 # v1.1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,9 @@ jobs:
     steps:
       - name: Get branch names
         id: branch-name
-        uses: tj-actions/branch-names@v7.0.7
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+        uses: tj-actions/branch-names@6c999acf206f5561e19f46301bb310e9e70d8815 # v7.0.7
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: ruby/setup-ruby@c95ae3725f6ebdd095f2bd19caed7ebc14435ba5 # v1.243.0
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
@@ -35,16 +35,16 @@ jobs:
   codeclimate:
     runs-on: ubuntu-latest
     steps:
-      - uses: tj-actions/branch-names@v7.0.7
+      - uses: tj-actions/branch-names@6c999acf206f5561e19f46301bb310e9e70d8815 # v7.0.7
         id: branch-name
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: ruby/setup-ruby@c95ae3725f6ebdd095f2bd19caed7ebc14435ba5 # v1.243.0
         with:
           ruby-version: 3.1.6
           bundler-cache: true
       - name: Test & publish code coverage
         if: "${{ env.CC_TEST_REPORTER_ID != '' }}"
-        uses: paambaati/codeclimate-action@v2.7.5
+        uses: paambaati/codeclimate-action@7bcf9e73c0ee77d178e72c0ec69f1a99c1afc1f3 # v2.7.5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
           GIT_BRANCH: ${{ steps.branch-name.outputs.current_branch }}
@@ -57,10 +57,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@c95ae3725f6ebdd095f2bd19caed7ebc14435ba5 # v1.243.0
         with:
           bundler-cache: true
           ruby-version: 3.1.6


### PR DESCRIPTION
# What

Close https://github.com/increments/graphql-kaminari_connection/issues/41

- Fix version of github actions by hash

# Refs

- https://docs.github.com/ja/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
