### PR TITLE
Remove codeclimate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,26 +32,6 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
       - run: bundle exec rspec
 
-  codeclimate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: tj-actions/branch-names@6c999acf206f5561e19f46301bb310e9e70d8815 # v7.0.7
-        id: branch-name
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-      - uses: ruby/setup-ruby@c95ae3725f6ebdd095f2bd19caed7ebc14435ba5 # v1.243.0
-        with:
-          ruby-version: 3.1.6
-          bundler-cache: true
-      - name: Test & publish code coverage
-        if: "${{ env.CC_TEST_REPORTER_ID != '' }}"
-        uses: paambaati/codeclimate-action@7bcf9e73c0ee77d178e72c0ec69f1a99c1afc1f3 # v2.7.5
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-          GIT_BRANCH: ${{ steps.branch-name.outputs.current_branch }}
-          GIT_COMMIT_SHA: ${{ github.sha }}
-        with:
-          coverageCommand: bundle exec rspec
-
   rubocop:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Gem](https://img.shields.io/gem/v/graphql-kaminari_connection.svg)](https://rubygems.org/gems/graphql-kaminari_connection)
 [![Build Status](https://travis-ci.org/increments/graphql-kaminari_connection.svg?branch=master)](https://travis-ci.org/increments/graphql-kaminari_connection)
-[![Code Climate](https://codeclimate.com/github/increments/graphql-kaminari_connection/badges/gpa.svg)](https://codeclimate.com/github/increments/graphql-kaminari_connection)
-[![Test Coverage](https://codeclimate.com/github/increments/graphql-kaminari_connection/badges/coverage.svg)](https://codeclimate.com/github/increments/graphql-kaminari_connection/coverage)
 [![license](https://img.shields.io/github/license/increments/graphql-kaminari_connection.svg)](https://github.com/increments/graphql-kaminari_connection/blob/master/LICENSE)
 
 

--- a/graphql-kaminari_connection.gemspec
+++ b/graphql-kaminari_connection.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'activerecord', '~> 6.0'
   spec.add_development_dependency 'appraisal', '~> 2.5'
   spec.add_development_dependency 'bundler', '~> 2.2'
-  spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0'
   spec.add_development_dependency 'concurrent-ruby', '< 1.3.5' # It is required by activerecord 6. see https://github.com/increments/graphql-kaminari_connection/issues/39.
   spec.add_development_dependency 'pry', '0.11.3'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
## What

- Remove codeclimate

## How

- Remove codeclimate badge from README
- Uninstall codeclimate-test-reporter gem
- Remove codeclimate CI

## Why
- Code Climate API was disabled
    - https://docs.qlty.sh/migration/guide