### PR TITLE
Introduce qlty

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,3 +47,18 @@ jobs:
 
       - name: Run rubocop
         run: bundle exec rubocop
+
+  qlty:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: ruby/setup-ruby@13e7a03dc3ac6c3798f4570bfead2aed4d96abfb # v1.244.0
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - name: Test
+        run: bundle exec rspec
+      - uses: qltysh/qlty-action/coverage@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
+        with:
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: ./coverage/coverage.json

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Gem](https://img.shields.io/gem/v/graphql-kaminari_connection.svg)](https://rubygems.org/gems/graphql-kaminari_connection)
 [![Build Status](https://travis-ci.org/increments/graphql-kaminari_connection.svg?branch=master)](https://travis-ci.org/increments/graphql-kaminari_connection)
 [![license](https://img.shields.io/github/license/increments/graphql-kaminari_connection.svg)](https://github.com/increments/graphql-kaminari_connection/blob/master/LICENSE)
+[![Maintainability](https://qlty.sh/gh/increments/projects/graphql-kaminari_connection/maintainability.svg)](https://qlty.sh/gh/increments/projects/graphql-kaminari_connection)
+[![Code Coverage](https://qlty.sh/gh/increments/projects/graphql-kaminari_connection/coverage.svg)](https://qlty.sh/gh/increments/projects/graphql-kaminari_connection)
 
 
 Kaminari based GraphQL pagination

--- a/graphql-kaminari_connection.gemspec
+++ b/graphql-kaminari_connection.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.69.2'
   spec.add_development_dependency 'rubocop-rspec', '~> 3.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.13'
+  spec.add_development_dependency 'simplecov_json_formatter', '~> 0.1.4'
   spec.add_development_dependency 'sqlite3', '~> 1.3'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,14 @@
 require 'bundler/setup'
 
 require 'simplecov'
+require 'simplecov_json_formatter'
+
 SimpleCov.start do
+  SimpleCov.formatters = [
+    SimpleCov::Formatter::JSONFormatter,
+    SimpleCov::Formatter::HTMLFormatter
+  ]
+
   add_filter '/spec/'
 end
 


### PR DESCRIPTION
## What

- Calculate and upload code coverage data to qlty during CI
- Make code coverage and Maintainability viewable from the README

## How

- Install `simplecov_json_formatter`
- Change the coverage output format to JSON
- Implement the coverage action from qlty
- Add a badge to the README


## Why

- The Code Climate API has been disabled
    - https://docs.qlty.sh/migration/guide

## REF

- https://github.com/increments/graphql-kaminari_connection/pull/42